### PR TITLE
Removing unused Environment.StackTrace and getting UserDomainName and UserName in constructor

### DIFF
--- a/ElasticSearch.Diagnostics/ElasticSearchTraceListener.cs
+++ b/ElasticSearch.Diagnostics/ElasticSearchTraceListener.cs
@@ -38,6 +38,9 @@ namespace ElasticSearch.Diagnostics
 
         private IElasticLowLevelClient _client;
 
+        private string _userDomainName;
+        private string _userName;
+
         /// <summary>
         /// Uri for the ElasticSearch server
         /// </summary>
@@ -160,7 +163,9 @@ namespace ElasticSearch.Diagnostics
         /// so keep the constructor at a minimum
         /// </summary>
         public ElasticSearchTraceListener() : base()
-        {
+	    {
+	        _userDomainName = Environment.UserDomainName;
+	        _userName = Environment.UserName;
             Initialize();
         }
 
@@ -170,6 +175,8 @@ namespace ElasticSearch.Diagnostics
         /// </summary>
         public ElasticSearchTraceListener(string name) : base(name)
         {
+            _userDomainName = Environment.UserDomainName;
+            _userName = Environment.UserName;
             Initialize();
         }
 
@@ -338,8 +345,8 @@ namespace ElasticSearch.Diagnostics
             IIdentity identity = principal?.Identity;
             string identityname = identity == null ? string.Empty : identity.Name;
 
-
-            string username = Environment.UserDomainName + "\\" + Environment.UserName;
+            
+            string username = $"{_userDomainName}\\{_userName}";
 
             try
             {

--- a/ElasticSearch.Diagnostics/ElasticSearchTraceListener.cs
+++ b/ElasticSearch.Diagnostics/ElasticSearchTraceListener.cs
@@ -223,10 +223,10 @@ namespace ElasticSearch.Diagnostics
             object data)
         {
 
-            if (eventCache != null && eventCache.Callstack.Contains(nameof(Elasticsearch.Net.ElasticLowLevelClient)))
-            {
-                return;
-            }
+            //if (eventCache != null && eventCache.Callstack.Contains(nameof(Elasticsearch.Net.ElasticLowLevelClient)))
+            //{
+            //    return;
+            //}
 
             string updatedMessage = message;
             JObject payload = null;

--- a/ElasticSearch.Diagnostics/ElasticSearchTraceListener.cs
+++ b/ElasticSearch.Diagnostics/ElasticSearchTraceListener.cs
@@ -301,10 +301,10 @@ namespace ElasticSearch.Diagnostics
             JObject dataObject)
         {
 
-            var timeStamp = DateTime.UtcNow.ToString("o");
+            //var timeStamp = DateTime.UtcNow.ToString("o");
             //var source = Process.GetCurrentProcess().ProcessName;
-            var stacktrace = Environment.StackTrace;
-            var methodName = (new StackTrace()).GetFrame(StackTrace.METHODS_TO_SKIP + 4).GetMethod().Name;
+            //var stacktrace = Environment.StackTrace;
+            //var methodName = (new StackTrace()).GetFrame(StackTrace.METHODS_TO_SKIP + 4).GetMethod().Name;
 
 
             DateTime logTime;
@@ -349,10 +349,10 @@ namespace ElasticSearch.Diagnostics
                         {"TraceId", traceId ?? 0},
                         {"EventType", eventType.ToString()},
                         {"UtcDateTime", logTime},
-                        {"timestamp", eventCache != null ? eventCache.Timestamp : 0},
+                        {"timestamp", eventCache?.Timestamp ?? 0},
                         {"MachineName", Environment.MachineName},
                         {"AppDomainFriendlyName", AppDomain.CurrentDomain.FriendlyName},
-                        {"ProcessId", eventCache != null ? eventCache.ProcessId : 0},
+                        {"ProcessId", eventCache?.ProcessId ?? 0},
                         {"ThreadName", thread},
                         {"ThreadId", threadId},
                         {"Message", message},

--- a/ElasticSearch.Diagnostics/ElasticSearchTraceListener.cs
+++ b/ElasticSearch.Diagnostics/ElasticSearchTraceListener.cs
@@ -166,6 +166,7 @@ namespace ElasticSearch.Diagnostics
 	    {
 	        _userDomainName = Environment.UserDomainName;
 	        _userName = Environment.UserName;
+	        _machineName = Environment.MachineName;
             Initialize();
         }
 
@@ -177,6 +178,7 @@ namespace ElasticSearch.Diagnostics
         {
             _userDomainName = Environment.UserDomainName;
             _userName = Environment.UserName;
+            _machineName = Environment.MachineName;
             Initialize();
         }
 
@@ -187,6 +189,7 @@ namespace ElasticSearch.Diagnostics
         }
 
         private Action<JObject> _scribeProcessor;
+        private string _machineName;
 
         private void SetupObserver()
         {
@@ -357,7 +360,7 @@ namespace ElasticSearch.Diagnostics
                         {"EventType", eventType.ToString()},
                         {"UtcDateTime", logTime},
                         {"timestamp", eventCache?.Timestamp ?? 0},
-                        {"MachineName", Environment.MachineName},
+                        {"MachineName", _machineName},
                         {"AppDomainFriendlyName", AppDomain.CurrentDomain.FriendlyName},
                         {"ProcessId", eventCache?.ProcessId ?? 0},
                         {"ThreadName", thread},


### PR DESCRIPTION
Removed unused Environment.StackTrace.  Closes #12 #14 